### PR TITLE
perf: make analyze_text and analyze_line around 50x faster.

### DIFF
--- a/chanda/core.py
+++ b/chanda/core.py
@@ -125,6 +125,12 @@ class Chanda:
         # Read Data
         self.read_data()
 
+        # Pre-compile regex patterns for all CHANDA keys
+        self._COMPILED_REGEX = {
+            pattern: re.compile(f'^{pattern}$')
+            for pattern in self.CHANDA
+        }
+
     ###########################################################################
 
     @functools.lru_cache(maxsize=MAX_CACHE)
@@ -1286,8 +1292,8 @@ class Chanda:
             lg_candidates.append(lg_str[:-1] + self.G)
         regex_matches = [
             pattern
-            for pattern in self.CHANDA
-            if any(re.match(f'^{pattern}$', candidate) for candidate in lg_candidates)
+            for pattern, compiled in self._COMPILED_REGEX.items()
+            if any(compiled.match(candidate) for candidate in lg_candidates)
         ]
 
         found = direct_match['found'] or multi_match['found'] or bool(regex_matches)
@@ -1431,6 +1437,13 @@ class Chanda:
     ###########################################################################
 
 
+
+@functools.lru_cache(maxsize=1)
+def _get_chanda_singleton(data_path: str, language: str) -> 'Chanda':
+    """Return a singleton Chanda instance, recreating it if args change."""
+    return Chanda(data_path, language=language)
+
+
 def analyze_line(
     text: str,
     fuzzy: bool = True,
@@ -1481,7 +1494,7 @@ def analyze_line(
         from .utils import get_default_data_path
         data_path = get_default_data_path()
 
-    analyzer = Chanda(data_path, language=language)
+    analyzer = _get_chanda_singleton(data_path, language)
     result = analyzer.analyze_line(
         text,
         fuzzy=fuzzy,
@@ -1539,7 +1552,7 @@ def analyze_text(
         from .utils import get_default_data_path
         data_path = get_default_data_path()
 
-    analyzer = Chanda(data_path, language=language)
+    analyzer = _get_chanda_singleton(data_path, language)
     results = analyzer.analyze_text(
         text,
         verse=verse_mode,


### PR DESCRIPTION
Two optimizations:

1. Python's regex cache has size `re._MAXCACHE` which on my system is `512`. `Chanda` uses more than 512 patterns with the default data file, which means that regexes are constantly evicted from the cache. The fix is to cache these patterns explicitly in a dictionary.

2. `analyze_line` and `analyze_text` create a `Chanda` instance on each call, which involves reading from disk. Use an `lru_cache` to cache the constructed `Chanda` for subsequent calls. We use a cache size of `1` to protect against the case where `chanda` is called with multiple data files, which would bloat memory.

Test plan: ran a simple profile script and saw a 50x speedup.